### PR TITLE
CASMCMS-7429 - Run as non-root user.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,14 +61,16 @@ COPY scripts/get-node /app/get-node
 ENV VAULT_ADDR="http://cray-vault.vault:8200"
 ENV VAULT_SKIP_VERIFY="true"
 
-RUN echo 'alias ll="ls -l"' > ~/.bashrc
-RUN echo 'alias vi="vim"' >> ~/.bashrc
+RUN echo 'alias ll="ls -l"' > /app/bashrc
 
 # add a bunch of debug aliases
-RUN echo 'alias health="curl -k -X GET http://localhost:26777/console-operator/health"' >> ~/.bashrc
-RUN echo 'alias info="curl -k -X GET http://localhost:26777/console-operator/info"' >> ~/.bashrc
-RUN echo 'alias suspend="curl -k -X POST http://localhost:26777/console-operator/suspend"' >> ~/.bashrc
-RUN echo 'alias resume="curl -k -X POST http://localhost:26777/console-operator/resume"' >> ~/.bashrc
-RUN echo 'alias clearData="curl -k -X DELETE http://localhost:26777/console-operator/clearData"' >> ~/.bashrc
+RUN echo 'alias health="curl -sk -X GET http://localhost:26777/console-operator/health"' >> /app/bashrc
+RUN echo 'alias info="curl -sk -X GET http://localhost:26777/console-operator/info"' >> /app/bashrc
+RUN echo 'alias suspend="curl -sk -X POST http://localhost:26777/console-operator/suspend"' >> /app/bashrc
+RUN echo 'alias resume="curl -sk -X POST http://localhost:26777/console-operator/resume"' >> /app/bashrc
+RUN echo 'alias clearData="curl -sk -X DELETE http://localhost:26777/console-operator/clearData"' >> /app/bashrc
+
+# set to user nobody so this won't run as root
+USER 65534:65534
 
 ENTRYPOINT ["/app/console_operator"]

--- a/kubernetes/cray-console-operator/templates/hook-postupgrade.yaml
+++ b/kubernetes/cray-console-operator/templates/hook-postupgrade.yaml
@@ -1,0 +1,24 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: console-post-upgrade
+  namespace: "services"
+  annotations:
+    "helm.sh/hook": "post-upgrade"
+spec:
+  template:
+    spec:
+      restartPolicy: Never
+      terminationGracePeriodSeconds: 0
+      containers:
+      - name: hook1-container
+        image: "baseos/alpine:3.13"
+        imagePullPolicy: IfNotPresent
+        command: ['sh', '-c', 'chown -Rv 65534:65534 /var/log && chmod -R 766 /var/log']
+        volumeMounts:
+          - mountPath: /var/log
+            name: cray-console-logs
+      volumes:
+        - name: cray-console-logs
+          persistentVolumeClaim:
+            claimName: cray-console-operator-data-claim


### PR DESCRIPTION
### Summary and Scope

Change console-operator service to run as user 'nobody' so it no longer runs as root.  This requires a post-upgrade helm hook to run to change existing pvc data so that files and directories are owned as the 'nobody' user and have the correct file permissions for 'nobody' to access correctly.

DOES THIS CHANGE INVOLVE ANY SCHEME CHANGES?  N

### Issues and Related PRs
* Resolves CASMCMS-7429

### Testing
Tested on:
* Mug

Were the install/upgrade based validation checks/tests run?(goss tests/install-validation doc)
Was a fresh Install tested? N - no csm-1.2 installs available yet
Was an Upgrade tested?      Y
Was a Downgrade tested?    Y

I manually upgraded/downgraded the service with helm upgrade/rollback.  The file permissions were checked to be correct and the service was verified to be working correctly.  I added some deeper checks and more severe errors in the service if the files could not be accessed correctly by the service.

### Risks and Mitigations

This is a fairly low risk change, but the cray-console-node service also uses the same pvc as here.  That service also needs to have the non-root user conversion completed.  