### PR TITLE
Refactor alpine image references

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN set -ex && go build -v -i -o /app/console_operator $GOPATH/src/console_op
 
 ### Final Stage ###
 # Start with a fresh image so build tools are not included
-FROM artifactory.algol60.net/docker.io/alpine:latest as base
+FROM artifactory.algol60.net/docker.io/library/alpine:latest as base
 
 # Install conman application from package
 RUN set -eux \

--- a/kubernetes/cray-console-operator/Chart.yaml
+++ b/kubernetes/cray-console-operator/Chart.yaml
@@ -21,5 +21,5 @@ annotations:
     - name: cray-console-operator
       image: artifactory.algol60.net/csm-docker/stable/cray-console-operator:0.0.0
     - name: alpine
-      image: artifactory.algol60.net/docker.io/alpine:latest
+      image: alpine:latest
   artifacthub.io/license: MIT

--- a/kubernetes/cray-console-operator/templates/hook-postupgrade.yaml
+++ b/kubernetes/cray-console-operator/templates/hook-postupgrade.yaml
@@ -12,8 +12,8 @@ spec:
       terminationGracePeriodSeconds: 0
       containers:
       - name: hook1-container
-        image: artifactory.algol60.net/docker.io/alpine:latest
-        imagePullPolicy: IfNotPresent
+        image: {{ .Values.alpine.image.repository }}:{{ .Values.alpine.image.tag }}
+        imagePullPolicy: {{ .Values.alpine.image.pullPolicy }}
         command: ['sh', '-c', 'chown -Rv 65534:65534 /var/log && chmod -R 766 /var/log']
         volumeMounts:
           - mountPath: /var/log

--- a/kubernetes/cray-console-operator/values.yaml
+++ b/kubernetes/cray-console-operator/values.yaml
@@ -81,3 +81,9 @@ cray-service:
     prefix: /apis/console-operator
   strategy:
     type: Recreate
+
+alpine:
+  image:
+    repository: alpine
+    tag: latest
+    pullPolicy: IfNotPresent


### PR DESCRIPTION
Add `alpine.image` settings to values.yaml in order to enable customization.

Change default alpine reference from `artifactory.algol60.net/docker.io/alpine:latest` to `alpine:latest`. Chart defaults should reference upstream locations instead of registry mirrors.

Supplements [CASMCMS-7616](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-7616). Required to resolve [CASM-2670](https://jira-pro.its.hpecorp.net:8443/browse/CASM-2670).