### PR TITLE
CASMCMS-7830 - Update alpine base image.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### Added
-
 ### Changed
+ - CASMCMS-7830: Update the base image to newer version.
 
 [1.0.0] - (no date)

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@
 # Dockerfile for cray-console-operator service
 
 # Build will be where we build the go binary
-FROM arti.dev.cray.com/baseos-docker-master-local/golang:1.14-alpine3.12 as build
+FROM artifactory.algol60.net/docker.io/library/golang:1.16-alpine as build
 RUN set -eux \
     && apk add --upgrade --no-cache apk-tools \
     && apk update \
@@ -40,11 +40,13 @@ COPY src/console_op $GOPATH/src/console_op
 COPY vendor/ $GOPATH/src
 
 # Build configure_conman
-RUN set -ex && go build -v -i -o /app/console_operator $GOPATH/src/console_op
+RUN set -ex \
+    && go env -w GO111MODULE=auto \
+    && go build -v -i -o /app/console_operator $GOPATH/src/console_op
 
 ### Final Stage ###
 # Start with a fresh image so build tools are not included
-FROM artifactory.algol60.net/docker.io/library/alpine:latest as base
+FROM artifactory.algol60.net/csm-docker/stable/docker.io/library/alpine:3.15 as base
 
 # Install conman application from package
 RUN set -eux \


### PR DESCRIPTION
## Summary and Scope

Update the alpine base image version and shift to the ones on algol60 that are being rebuilt nightly for better automatic CVE remediation.

## Issues and Related PRs
* Resolves [CASMCMS-7830](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-7830)

## Testing
### Tested on:
  * `Drax`

### Test description:

Installed via helm on Drax with the other console services.  Did complete test with flushing cached data and made sure all new services came up and operated as expected, including connecting to live console sessions on compute nodes.  Rolled back to previous installed version when complete and re-tested.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N - not applicable
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

Fairly minor risk - there are no major dependencies on the base images and was completely tested on a live system.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

