### PR TITLE
CASMCMS-8140 - correctly handle Hill nodes.

### DIFF
--- a/src/console_op/consoleOpMain.go
+++ b/src/console_op/consoleOpMain.go
@@ -95,7 +95,7 @@ func doHardwareUpdate(updateAll, redeployMtnKeys bool) (updateSuccess, keySucces
 			// add the item to the cached items and record as new
 			nodeCache[n.NodeName] = n
 			newNodes = append(newNodes, n)
-			if n.Class == "Mountain" {
+			if n.isMountain() {
 				newMtnNodes = append(newMtnNodes, n)
 			}
 			log.Printf("Found new node: %s", n.String())
@@ -127,7 +127,7 @@ func doHardwareUpdate(updateAll, redeployMtnKeys bool) (updateSuccess, keySucces
 		}
 
 		// gather all mountain nodes if forcing full key regeneration
-		if redeployMtnKeys && v.Class == "Mountain" {
+		if redeployMtnKeys && v.isMountain() {
 			newMtnNodes = append(newMtnNodes, v)
 		}
 
@@ -146,9 +146,9 @@ func doHardwareUpdate(updateAll, redeployMtnKeys bool) (updateSuccess, keySucces
 			removedNodes = append(removedNodes, v)
 		} else {
 			// update counts of nodes
-			if v.Class == "River" {
+			if v.isRiver() {
 				numRvrNodes++
-			} else if v.Class == "Mountain" {
+			} else if v.isMountain() {
 				numMtnNodes++
 			} else {
 				log.Printf("Error: unknown node class: %s on node: %s", v.Class, v.NodeName)

--- a/src/console_op/creds.go
+++ b/src/console_op/creds.go
@@ -340,7 +340,7 @@ func ensureMountainConsoleKeysDeployed(nodes []nodeConsoleInfo) bool {
 	// both nodes.
 	mtnBmcList := make(map[string]string)
 	for _, nodeCi := range nodes {
-		if nodeCi.Class == "Mountain" {
+		if nodeCi.isMountain() {
 			mtnBmcList[nodeCi.BmcFqdn] = nodeCi.BmcName
 		}
 	}

--- a/src/console_op/nodes.go
+++ b/src/console_op/nodes.go
@@ -45,6 +45,16 @@ type nodeConsoleInfo struct {
 	Role     string // role of the node
 }
 
+// Function to determine if a node is Mountain hardware
+func (node nodeConsoleInfo) isMountain() bool {
+	return node.Class == "Mountain" || node.Class == "Hill"
+}
+
+// Function to determine if a node is River hardware
+func (node nodeConsoleInfo) isRiver() bool {
+	return node.Class == "River"
+}
+
 // Provide a function to convert struct to string
 func (nc nodeConsoleInfo) String() string {
 	return fmt.Sprintf("NodeName:%s, BmcName:%s, BmcFqdn:%s, Class:%s, NID:%d, Role:%s",


### PR DESCRIPTION
## Summary and Scope

In csm-1.2, hsm changed so that the 'node class' can be either 'Mountain', 'River', or 'Hill'.  The 'hill' types were not getting picked up by console services.  This set of changes looks for records containing 'Hill' and treats them correctly.

## Issues and Related PRs
* Resolves [CASMCMS-8140](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8140)

## Testing
### Tested on:

  * `Loki`

### Test description:

I installed the new version via helm and observed that Hill nodes were correctly picked up by console services and connections and logging were established.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? Y

## Risks and Mitigations

This is a fairly low risk change, it just needs to handle the 'Hill' type in the existing records.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
