### PR TITLE
CASMTRIAGE-4899 - fix post-install and post-update helm hooks.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+## [1.6.2] - 2023-02-03
+### Changed
+- CASMTRIAGE-4899 - fix post-install and post-update hooks.
+
 ## [1.6.1] - 2022-12-20
 ### Added
 - Add Artifactory authentication to Jenkinsfile

--- a/kubernetes/cray-console-operator/templates/hook-postupgrade.yaml
+++ b/kubernetes/cray-console-operator/templates/hook-postupgrade.yaml
@@ -27,7 +27,8 @@ metadata:
   name: console-post-upgrade
   namespace: "services"
   annotations:
-    "helm.sh/hook": "post-upgrade"
+    "helm.sh/hook": post-upgrade,post-install
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   template:
     spec:


### PR DESCRIPTION
## Summary and Scope

The post-install hook on this corrects any wrong dir ownership and permissions on the shared PVC so it needs to run after install AND upgrade. This is the chart that creates the PVC, so this is the one that should fix the ownership and permissions. 

## Issues and Related PRs
* Resolves [CASMTRIAGE-4899](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-4899)

## Testing
### Tested on:
  * `Fanta`

### Test description:

I used helm to install/uninstall this and console-node together in every combination I could think of. If node is installed first, it will wait in 'pending' until the PVC is created when operator is installed. The operator install/upgrade will create the PVC and fix the ownership and permissions of the dirs needed. If operator is installed first, it will create the PVC and node installs and starts correctly without issue.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

This should be low risk, but I thought that with the update to the console-node helm charts as well...

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

