### PR TITLE
CASMCMS-8423 - linting changes for new gofmt version.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [1.6.3] - 2023-02-24
+### Changed
+- CASMCMS-8423 - linting changes for new gofmt version.
+
 ## [1.6.2] - 2023-02-03
 ### Changed
 - CASMTRIAGE-4899 - fix post-install and post-update hooks.

--- a/src/console_op/consoleOpMain.go
+++ b/src/console_op/consoleOpMain.go
@@ -1,7 +1,7 @@
 //
 //  MIT License
 //
-//  (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+//  (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a
 //  copy of this software and associated documentation files (the "Software"),
@@ -56,11 +56,11 @@ var numNodePods int = -1
 var numRvrNodesPerPod int = -1
 var numMtnNodesPerPod int = -1
 
-// NOTE: the maximum number of river/mountain nodes per pod are
-//  based on testing on Shasta systems at this time.  These numbers
-//  may need to be adjusted with more testing time on large systems.
-//  These are considered to be hard maximums and pods will be scaled
-//  so no pod will try to connect to more than this.
+// The maximum number of river/mountain nodes per pod are
+// based on testing on Shasta systems at this time.  These numbers
+// may need to be adjusted with more testing time on large systems.
+// These are considered to be hard maximums and pods will be scaled
+// so no pod will try to connect to more than this.
 var maxMtnNodesPerPod int = 750
 var maxRvrNodesPerPod int = 2000
 


### PR DESCRIPTION
## Summary and Scope

There was a new version of 'go' installed on the image for the build pipeline. The new 'gofmt' linter objected to a couple of the comments and forced us to change them to allow the linting step to complete happily so the build would complete.

## Issues and Related PRs
* Resolves [CASMCMS-8423](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8423)

## Testing
### Tested on:
  * `Surtur`

### Test description:

Installed the new version on surtur and verified the console services work correctly.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? Y 
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

Very low risk - just changing the format of comments.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

