### PR TITLE
CASMCMS-7167: Adding replica API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added dependency injection to allow for unit testing
 - Added <https://pkg.go.dev/github.com/go-chi/chi/v5@v5.0.7> for routing. Lock at v5.0.7 due to golang version bump in v5.0.8
-- CASMCMS-7167 - Adding pod location API to enable monitoring resiliency
+- CASMCMS-7167 - Adding pod location API, replica API to enable monitoring resiliency.
 
 ## [1.6.3] - 2023-02-24
 ### Changed

--- a/src/console_op/data.go
+++ b/src/console_op/data.go
@@ -1,7 +1,7 @@
 //
 //  MIT License
 //
-//  (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+//  (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a
 //  copy of this software and associated documentation files (the "Software"),

--- a/src/console_op/data.go
+++ b/src/console_op/data.go
@@ -47,6 +47,7 @@ type DataService interface {
 	checkHeartbeats()
 	doGetPodLocation(w http.ResponseWriter, r *http.Request)
 	doGetNodePod(w http.ResponseWriter, r *http.Request)
+	doGetPodReplicaCount(w http.ResponseWriter, r *http.Request)
 	getNodePodForXname(xname string) (string, error)
 }
 
@@ -173,6 +174,10 @@ type GetNodePodResponse struct {
 // GetNodeData - input data for call to getNodeData
 type GetNodeData struct {
 	XName string `json:"xname"`
+}
+
+type GetNodeReplicasResponse struct {
+	Replicas int `json:"replicas"`
 }
 
 // doGetPodLocation response data
@@ -353,4 +358,28 @@ func (DataManager) getNodePodForXname(xname string) (string, error) {
 
 	// return the result
 	return fmt.Sprintf("cray-console-node-%s", nd.NodeConsoleName), nil
+}
+
+func (dm DataManager) doGetPodReplicaCount(w http.ResponseWriter, r *http.Request) {
+	// only allow 'GET' calls
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", "GET")
+		sendJSONError(w, http.StatusMethodNotAllowed,
+			fmt.Sprintf("(%s) Not Allowed", r.Method))
+		return
+	}
+
+	nodeRepCount, err := dm.k8Service.getReplicaCount()
+	if err != nil {
+		log.Printf("Error: There was an error while retrieving console-node replica counts: %s\n", err)
+		var body = BaseResponse{
+			Msg: fmt.Sprintf("There was an error while retrieving console-node replica counts: %s\n", err),
+		}
+		SendResponseJSON(w, http.StatusInternalServerError, body)
+	}
+
+	var resp GetNodeReplicasResponse
+	resp.Replicas = nodeRepCount
+	SendResponseJSON(w, http.StatusOK, resp)
+	return
 }

--- a/src/console_op/k8s.go
+++ b/src/console_op/k8s.go
@@ -1,7 +1,7 @@
 //
 //  MIT License
 //
-//  (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+//  (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a
 //  copy of this software and associated documentation files (the "Software"),
@@ -127,10 +127,10 @@ func (k8s K8Manager) getReplicaCount() (replicaCnt int, err error) {
 		log.Printf("StatefulSet cray-console-node not found in services namespace\n")
 		return consoleNodeRepCount, err
 	} else if statusError, isStatus := err.(*errors.StatusError); isStatus {
-		log.Printf("Error getting statefulSet %v\n", statusError.ErrStatus.Message)
+		log.Printf("Error getting statefulSet cray-console-node in services namespace: %v\n", statusError.ErrStatus.Message)
 		return consoleNodeRepCount, err
 	} else if err != nil {
-		log.Printf("Unknown error getting statefulSet: %s", err.Error())
+		log.Printf("Unknown error getting statefulSet cray-console-node in services namespace: %s", err.Error())
 		return consoleNodeRepCount, err
 	}
 

--- a/src/console_op/k8s.go
+++ b/src/console_op/k8s.go
@@ -46,6 +46,7 @@ const targetNodeFile string = "/var/log/console/TargetNodes.txt"
 
 type K8Service interface {
 	printK8sInfo()
+	getReplicaCount() (replicaCnt int, err error)
 	updateReplicaCount(newReplicaCnt int)
 	updateNodesPerPod(newNumMtn, newNumRvr int)
 	getPodLocationAlias(podID string) (loc string, err error)
@@ -57,7 +58,7 @@ type K8Manager struct {
 	clientset *kubernetes.Clientset
 }
 
-func NewK8Manager() (K8Service, error) {
+func NewK8Manager() (*K8Manager, error) {
 	// creates the in-cluster config
 	var err error
 	var config *rest.Config = nil
@@ -115,6 +116,26 @@ func (k8s K8Manager) printK8sInfo() {
 		fmt.Printf("Found cray-conman pod in default namespace\n")
 	}
 
+}
+
+// Grab the current number of console-node replicas from k8s
+func (k8s K8Manager) getReplicaCount() (replicaCnt int, err error) {
+	// get the stateful set
+	consoleNodeRepCount := -1
+	dep, err := k8s.clientset.AppsV1().StatefulSets("services").Get("cray-console-node", metav1.GetOptions{})
+	if errors.IsNotFound(err) {
+		log.Printf("StatefulSet cray-console-node not found in services namespace\n")
+		return consoleNodeRepCount, err
+	} else if statusError, isStatus := err.(*errors.StatusError); isStatus {
+		log.Printf("Error getting statefulSet %v\n", statusError.ErrStatus.Message)
+		return consoleNodeRepCount, err
+	} else if err != nil {
+		log.Printf("Unknown error getting statefulSet: %s", err.Error())
+		return consoleNodeRepCount, err
+	}
+
+	consoleNodeRepCount = int(*dep.Spec.Replicas)
+	return consoleNodeRepCount, nil
 }
 
 // Function to update the number of console-node replicas

--- a/src/console_op/router.go
+++ b/src/console_op/router.go
@@ -52,4 +52,5 @@ func setupRoutes(ds DataService, hs HealthService, dbs DebugService) {
 
 	// v1
 	router.Get("/console-operator/v1/location/{podID}", ds.doGetPodLocation)
+	router.Get("/console-operator/v1/replicas", ds.doGetPodReplicaCount)
 }


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

Adding API to expose the console-node replica counts through k8s. This allows the console-data to check to see if resiliency filtering is required or not. If there is only 1 replica then console-data will not filter, 2 or more replicas should implement filtering.

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_
backwards compatible

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-7167

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `mug`

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

