### PR TITLE
CASMCMS-8899 - add support for Paradise nodes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- CASMCMS-8899 - add support for Paradise (xd224) nodes.
+
 ### Changed
 - Disabled concurrent Jenkins builds on same branch/commit
 - Added build timeout to avoid hung builds

--- a/src/console_op/consoleOpMain.go
+++ b/src/console_op/consoleOpMain.go
@@ -1,7 +1,7 @@
 //
 //  MIT License
 //
-//  (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+//  (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a
 //  copy of this software and associated documentation files (the "Software"),
@@ -154,7 +154,7 @@ func doHardwareUpdate(ds DataService, ns NodeService, updateAll bool, mountainCr
 		// update counts of nodes
 		if v.isRiver() {
 			numRvrNodes++
-		} else if v.isMountain() {
+		} else if v.isMountain() || v.isParadise() {
 			numMtnNodes++
 		} else {
 			log.Printf("Error: unknown node class: %s on node: %s", v.Class, v.NodeName)
@@ -195,7 +195,7 @@ func watchHardware(ds DataService, ns NodeService) {
 		//  do not perform the hardware update check
 		if !inShutdown {
 			// do the update
-			updateSucessful := doHardwareUpdate(ds, ns, forceUpdateCnt == 0, mountainCredsUpdateChannel)
+			updateSuccessful := doHardwareUpdate(ds, ns, forceUpdateCnt == 0, mountainCredsUpdateChannel)
 
 			// set up for next update - normal countdown
 			forceUpdateCnt--
@@ -205,7 +205,7 @@ func watchHardware(ds DataService, ns NodeService) {
 			}
 
 			// look for failure - override complete update on failure
-			if !updateSucessful {
+			if !updateSuccessful {
 				forceUpdateCnt = 0
 			}
 		}

--- a/src/console_op/creds.go
+++ b/src/console_op/creds.go
@@ -1,7 +1,7 @@
 //
 //  MIT License
 //
-//  (C) Copyright 2020-2023 Hewlett Packard Enterprise Development LP
+//  (C) Copyright 2020-2024 Hewlett Packard Enterprise Development LP
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a
 //  copy of this software and associated documentation files (the "Software"),
@@ -230,7 +230,7 @@ func vaultGetMountainConsoleCredentials() error {
 		log.Printf("Unable to authenticate to Vault: %s", err)
 		return fmt.Errorf("Unable to authenticate to Vault: %s", err)
 	}
-	// If the response code is not 200 then we failed authenticaton.
+	// If the response code is not 200 then we failed authentication.
 	if responseCode != 200 {
 		log.Printf(
 			"Vault authentication failed.  Response code: %d  Message: %s",
@@ -423,7 +423,7 @@ func deployMountainConsoleKeys(nodes []nodeConsoleInfo) (bool, scsdList) {
 	// Call the HMS scsd service to deploy the public key.
 	log.Print("Calling scsd to deploy Mountain BMC ssh key(s)")
 	URL := "http://cray-scsd/v1/bmc/loadcfg"
-	data, rc, err := postURL(URL, jsonScsdParam, nil)
+	data, rc, _ := postURL(URL, jsonScsdParam, nil)
 
 	// consider any http return code < 400 as success
 	success := rc < 300
@@ -450,7 +450,7 @@ func deployMountainConsoleKeys(nodes []nodeConsoleInfo) (bool, scsdList) {
 	//  {"Xname":"x5000c2s5b0","StatusCode":422,"StatusMsg":"Target 'x5000c2s5b0' in bad HSM state: Unknown"}
 	//  {"Xname":"x5000c3r1b0","StatusCode":500,"StatusMsg":"Internal Server Error"}
 	//
-	// In addition perhpas we want to keep a map (map[string]string) of hostname to
+	// In addition perhaps we want to keep a map (map[string]string) of hostname to
 	// public key as a record of the deployment success or errors on a per
 	// BMC and public key basis.  This could be used in the future to reduce the time
 	// to redeploy all keys.

--- a/src/console_op/data.go
+++ b/src/console_op/data.go
@@ -1,7 +1,7 @@
 //
 //  MIT License
 //
-//  (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+//  (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a
 //  copy of this software and associated documentation files (the "Software"),
@@ -321,7 +321,6 @@ func (dm DataManager) doGetNodePod(w http.ResponseWriter, r *http.Request) {
 	var res GetNodePodResponse
 	res.PodName = podName
 	SendResponseJSON(w, http.StatusOK, res)
-	return
 }
 
 // query the console-data service for the correct pod
@@ -348,7 +347,7 @@ func (DataManager) getNodePodForXname(xname string) (string, error) {
 	var nd RetNodeConsoleInfo
 	err = json.Unmarshal(rd, &nd)
 	if err != nil {
-		log.Printf("Error unmashalling data from console-data: %s", err)
+		log.Printf("Error unmarshalling data from console-data: %s", err)
 		return "", err
 	}
 
@@ -377,5 +376,4 @@ func (dm DataManager) doGetPodReplicaCount(w http.ResponseWriter, r *http.Reques
 	var resp GetNodeReplicasResponse
 	resp.Replicas = nodeRepCount
 	SendResponseJSON(w, http.StatusOK, resp)
-	return
 }

--- a/src/console_op/debug.go
+++ b/src/console_op/debug.go
@@ -1,7 +1,7 @@
 //
 //  MIT License
 //
-//  (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+//  (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a
 //  copy of this software and associated documentation files (the "Software"),
@@ -141,7 +141,6 @@ func (dm DebugManager) doSetMaxNodesPerPod(w http.ResponseWriter, r *http.Reques
 
 	// write the response
 	w.WriteHeader(http.StatusOK)
-	return
 }
 
 // NodePodPair - information for which console-node pod an xname is controlled by
@@ -191,7 +190,6 @@ func (dm DebugManager) doInfo(w http.ResponseWriter, r *http.Request) {
 
 	// write the response
 	SendResponseJSON(w, http.StatusOK, info)
-	return
 }
 
 // Debugging only - clear all current data from services
@@ -220,7 +218,6 @@ func (dm DebugManager) doClearData(w http.ResponseWriter, r *http.Request) {
 
 	// write the response
 	w.WriteHeader(http.StatusOK)
-	return
 }
 
 // Debugging only - suspend querying the state manager
@@ -239,7 +236,6 @@ func (DebugManager) doSuspend(w http.ResponseWriter, r *http.Request) {
 	log.Printf("Updates suspended")
 	// write the response
 	w.WriteHeader(http.StatusOK)
-	return
 }
 
 // Debugging only - resume querying the state manager
@@ -259,5 +255,4 @@ func (DebugManager) doResume(w http.ResponseWriter, r *http.Request) {
 
 	// write the response
 	w.WriteHeader(http.StatusOK)
-	return
 }

--- a/src/console_op/health.go
+++ b/src/console_op/health.go
@@ -1,7 +1,7 @@
 //
 //  MIT License
 //
-//  (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+//  (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a
 //  copy of this software and associated documentation files (the "Software"),
@@ -119,7 +119,6 @@ func (HealthManager) doLiveness(w http.ResponseWriter, r *http.Request) {
 
 	// return simple StatusOK response to indicate server is alive
 	w.WriteHeader(http.StatusNoContent)
-	return
 }
 
 // Basic readiness probe
@@ -138,5 +137,4 @@ func (HealthManager) doReadiness(w http.ResponseWriter, r *http.Request) {
 
 	// return simple StatusOK response to indicate server is alive
 	w.WriteHeader(http.StatusNoContent)
-	return
 }

--- a/src/console_op/httpUtils.go
+++ b/src/console_op/httpUtils.go
@@ -1,7 +1,7 @@
 //
 //  MIT License
 //
-//  (C) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
+//  (C) Copyright 2019-2022, 2024 Hewlett Packard Enterprise Development LP
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a
 //  copy of this software and associated documentation files (the "Software"),
@@ -94,6 +94,7 @@ func getURL(URL string, requestHeaders map[string]string) ([]byte, int, error) {
 		return nil, -1, err
 	}
 	log.Printf("getURL Response Status code: %d\n", resp.StatusCode)
+	defer resp.Body.Close()
 	data, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		// handle error

--- a/src/console_op/nodes.go
+++ b/src/console_op/nodes.go
@@ -1,7 +1,7 @@
 //
 //  MIT License
 //
-//  (C) Copyright 2019-2023 Hewlett Packard Enterprise Development LP
+//  (C) Copyright 2019-2024 Hewlett Packard Enterprise Development LP
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a
 //  copy of this software and associated documentation files (the "Software"),
@@ -53,6 +53,12 @@ func NewNodeManager(k8Service K8Service) NodeService {
 
 // Struct to hold all node level information needed to form a console connection
 // NOTE: this is the basic unit of information required for each node
+// NOTE: expected values for 'Class' are:
+//
+//	Mountain - Cray hardware in full liquid cooled rack (ssh via key)
+//	Hill - Cray hardware in freestanding rack (ssh via key)
+//	River - Other brand hardware in freestanding rack (ipmi via user/password)
+//	Paradise - Cray xd224 - foxconn bmc (ssh via user/password)
 type nodeConsoleInfo struct {
 	NodeName string // node xname
 	BmcName  string // bmc xname
@@ -70,6 +76,11 @@ func (node nodeConsoleInfo) isMountain() bool {
 // Function to determine if a node is River hardware
 func (node nodeConsoleInfo) isRiver() bool {
 	return node.Class == "River"
+}
+
+// Function to determine if a node is Paradise hardware
+func (node nodeConsoleInfo) isParadise() bool {
+	return node.Class == "Paradise"
 }
 
 // Provide a function to convert struct to string
@@ -158,6 +169,61 @@ func (NodeManager) getStateComponents() ([]stateComponent, error) {
 	return rp.Components, nil
 }
 
+// Query hsm for Paradise (xd224) nodes
+func (NodeManager) getParadiseNodes() (map[string]struct{}, error) {
+	// Paradise nodes are identified by having the manufacturer as 'Foxconn' and
+	// the model as either 'HPE Cray Supercomputing XD224' or '1A62WCB00-600-G'.
+	// There are a limited number of units that were sent to the field with the
+	// incorrect model '1A62WCB00-600-G' so we must support that.
+
+	// Structs to unmarshal the inventory data we care about
+	type HsmNodeFRUInfo struct {
+		Model        string
+		Manufacturer string
+		PartNumber   string
+		SerialNumber string
+	}
+	type HsmPopulatedFRU struct {
+		Type        string
+		Subtype     string
+		NodeFRUInfo HsmNodeFRUInfo
+	}
+	type HsmHardwareInventoryItem struct {
+		ID           string
+		Type         string
+		PopulatedFRU HsmPopulatedFRU
+	}
+
+	// Query hsm to get the Paradise nodes
+	// NOTE: this only pulls the Foxconn BMCs from the inventory so there is a bit of
+	//  server side filtering going on
+	URL := "http://cray-smd/hsm/v2/Inventory/Hardware?Manufacturer=Foxconn&Type=Node"
+	data, _, err := getURL(URL, nil)
+	if err != nil {
+		log.Printf("Unable to get hardware inventory from hsm:%s", err)
+		return nil, err
+	}
+
+	// decode the response
+	rp := []HsmHardwareInventoryItem{}
+	err = json.Unmarshal(data, &rp)
+	if err != nil {
+		log.Printf("Error unmarshalling data: %s", err)
+		return nil, err
+	}
+
+	// create a set of the Paradise items
+	nodes := map[string]struct{}{}
+	for _, node := range rp {
+		if node.PopulatedFRU.NodeFRUInfo.Model == "HPE Cray Supercomputing XD224" ||
+			node.PopulatedFRU.NodeFRUInfo.Model == "1A62WCB00-600-G" {
+			nodes[node.ID] = struct{}{}
+		}
+	}
+
+	return nodes, nil
+}
+
 func (nm NodeManager) getCurrentNodesFromHSM() (nodes []nodeConsoleInfo) {
 	// Get the BMC IP addresses and user, and password for individual nodes.
 	// conman is only set up for River nodes.
@@ -176,6 +242,14 @@ func (nm NodeManager) getCurrentNodesFromHSM() (nodes []nodeConsoleInfo) {
 		return nil
 	}
 
+	// get the paradise nodes
+	// NOTE: this returns a pseudo-set to speed up lookups
+	paradiseNodes, err := nm.getParadiseNodes()
+	if err != nil {
+		// log the error but don't die - most systems will not have Paradise nodes anyway
+		log.Printf("Unable to identify if there are any Paradise nodes on the system. %s", err)
+	}
+
 	// create a lookup map for the redfish information
 	rfMap := make(map[string]redfishEndpoint)
 	for _, rf := range rfEndpoints {
@@ -184,11 +258,15 @@ func (nm NodeManager) getCurrentNodesFromHSM() (nodes []nodeConsoleInfo) {
 
 	// create river and mountain node information
 	nodes = nil
-	var xnames []string = nil
 	for _, sc := range stComps {
 		if sc.Type == "Node" {
 			// create a new entry for this node - take initial vals from state component info
 			newNode := nodeConsoleInfo{NodeName: sc.ID, Class: sc.Class, NID: sc.NID, Role: sc.Role}
+
+			// If this is a paradise node, switch the class name
+			if _, isParadise := paradiseNodes[sc.ID]; isParadise {
+				newNode.Class = "Paradise"
+			}
 
 			// pull information about the node BMC from the redfish information
 			bmcName := sc.ID[0:strings.LastIndex(sc.ID, "n")]
@@ -202,9 +280,6 @@ func (nm NodeManager) getCurrentNodesFromHSM() (nodes []nodeConsoleInfo) {
 				// add to the list of nodes
 				nodes = append(nodes, newNode)
 
-				// add to list of bmcs to get creds from
-				//log.Printf("Added node: %s", newNode)
-				xnames = append(xnames, bmcName)
 			} else {
 				log.Printf("Node with no BMC present: %s, bmcName:%s", sc.ID, bmcName)
 			}
@@ -247,7 +322,7 @@ func (nm NodeManager) updateNodeCounts(numMtnNodes, numRvrNodes int) {
 
 	// update the number of mtn + river consoles to watch per pod
 	// NOTE: adding a little slop to how many each pod wants
-	// needed for worst case where a replica can aquire more nodes
+	// needed for worst case where a replica can acquire more nodes
 	// however, the only available nodes are themselves. Adding the replica counts
 	// will allow room to avoid orphaned mtn or rvr nodes.
 	newMtn := int(math.Ceil(float64(numMtnNodes)/float64(newNumPods)) + 1)


### PR DESCRIPTION
## Summary and Scope

Paradise nodes (Cray xd224) needs to connect to the consoles through ssh but with a username and password, which is a different way of connecting than to regular river, mountain, or hill nodes. The changes in this service mostly have to do with identifying and labeling nodes that are paradise hardware.

## Issues and Related PRs
* Resolves [CASMCMS-8899](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8899)

## Testing
### Tested on:
  * `Tyr`

### Test description:

The new services were installed via helm and I manually tested that the existing mountain, hill, river, and paradise nodes all are identified correctly and the console services can connect with them.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

This is a low risk, but there are changes that impact the other node types as well as the new paradise nodes.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

