### PR TITLE
CASMCMS-9147 - stop using alpine:latest base image.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- CASMCMS-9147 - stop using alpine:latest base image.
 
 ## [1.9.2] - 2024-09-16
 ### Dependencies

--- a/kubernetes/cray-console-operator/Chart.yaml
+++ b/kubernetes/cray-console-operator/Chart.yaml
@@ -44,5 +44,5 @@ annotations:
     - name: cray-console-operator
       image: artifactory.algol60.net/csm-docker/S-T-A-B-L-E/cray-console-operator:0.0.0-image
     - name: alpine
-      image: alpine:latest
+      image: artifactory.algol60.net/csm-docker/stable/docker.io/library/alpine:3
   artifacthub.io/license: MIT

--- a/kubernetes/cray-console-operator/values.yaml
+++ b/kubernetes/cray-console-operator/values.yaml
@@ -107,6 +107,6 @@ cray-service:
 
 alpine:
   image:
-    repository: alpine
-    tag: latest
+    repository: artifactory.algol60.net/csm-docker/stable/docker.io/library/alpine
+    tag: 3
     pullPolicy: IfNotPresent


### PR DESCRIPTION
## Summary and Scope

Replace instances of the 'alpine:latest' base image with the version we rebuild nightly to incorporate new security updates.

## Issues and Related PRs
* Resolves [CASMCMS-9147](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9147)

## Testing
### Tested on:

  * `Fanta`

### Test description:

Installed via helm upgrade and insured that all services using the updated alpine base image are working correctly.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

This is a fairly low risk change. Just re-installing a missing utility and using a different source for basically the same alpine base images.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
