### PR TITLE
CASMTRIAGE-7594 - improve node acquasition and rebalance.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- CASMTRIAGE-7594 - clean up resilience, rebalance nodes, and accept other worker nodes
+- CASMCMS-9035 - remove sshd from the image since it is not needed and adds security risks.
 
 ## [1.11.0] - 2024-10-15
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ FROM artifactory.algol60.net/csm-docker/stable/docker.io/library/alpine:3.15 as 
 RUN set -eux \
 	&& apk add --upgrade --no-cache apk-tools \
     && apk update \
-    && apk add --no-cache less openssh jq curl tar inotify-tools \
+    && apk add --no-cache less openssh-client jq curl tar inotify-tools \
     && apk -U upgrade --no-cache
 
 # Copy in the needed files
@@ -73,6 +73,7 @@ RUN echo 'alias info="curl -sk -X GET http://localhost:26777/console-operator/in
 RUN echo 'alias suspend="curl -sk -X POST http://localhost:26777/console-operator/suspend"' >> /app/bashrc
 RUN echo 'alias resume="curl -sk -X POST http://localhost:26777/console-operator/resume"' >> /app/bashrc
 RUN echo 'alias clearData="curl -sk -X DELETE http://localhost:26777/console-operator/clearData"' >> /app/bashrc
+RUN echo 'alias activeNodePods="curl -sk -X GET http://cray-console-data/v1/activepods"' >> /app/bashrc
 
 # set to user nobody so this won't run as root
 USER 65534:65534

--- a/src/console_op/consoleOpMain.go
+++ b/src/console_op/consoleOpMain.go
@@ -55,6 +55,8 @@ var numNodePods int = -1
 // startup until console-data is populated
 var numRvrNodesPerPod int = -1
 var numMtnNodesPerPod int = -1
+var totalRvrNodes int = -1
+var totalMtnNodes int = -1
 
 // The maximum number of river/mountain nodes per pod are
 // based on testing on Shasta systems at this time.  These numbers

--- a/src/console_op/nodes.go
+++ b/src/console_op/nodes.go
@@ -305,6 +305,10 @@ func (nm NodeManager) updateNodeCounts(numMtnNodes, numRvrNodes int) {
 		return
 	}
 
+	// cache the number of each type of node
+	totalRvrNodes = numRvrNodes
+	totalMtnNodes = numMtnNodes
+
 	// lets be extra paranoid about divide by zero issues...
 	mm := math.Max(float64(maxMtnNodesPerPod), 1)
 	mr := math.Max(float64(maxRvrNodesPerPod), 1)

--- a/src/console_op/router.go
+++ b/src/console_op/router.go
@@ -53,4 +53,5 @@ func setupRoutes(ds DataService, hs HealthService, dbs DebugService) {
 	// v1
 	router.Get("/console-operator/v1/location/{podID}", ds.doGetPodLocation)
 	router.Get("/console-operator/v1/replicas", ds.doGetPodReplicaCount)
+	router.Get("/console-operator/v1/currentTargets", ds.doGetCurrentTargets)
 }


### PR DESCRIPTION
## Summary and Scope

There was a problem where a worker node's console was not being monitored by anyone because it was getting assigned/unassigned to the console-node pod that was running on that worker and the other pod didn't have capacity to pick it up. The end result was it was getting picked up and dropped continually while forcing the conmand process to keep getting killed (resulting in incomplete logging of all the nodes in that pod).

The fix was to rework how node acquisition and rebalancing happens to be much more stable and aware of the current status of the services. This fix requires changes in all three console repos.

At the same time I added a change to remove sshd from the base image as it is not needed and it will prevent future CVS's around ssh vulnerabilities.

## Issues and Related PRs
* Resolves [CASMTRIAGE-7594](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7594)
* Resolves [CASMCMS-9035](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9035)

## Testing
### Tested on:
  * `Surtur`

### Test description:

I installed all 3 new versions of the console services and monitored the node acquisition through pod rollout, then forced pod failures to insure the remaining pods picked up the orphaned nodes, then correctly rebalanced when all console-node pods were back up and running.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? N
- Was downgrade tested? If not, why? N
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

This is a medium size change, but I spent several days testing in all situations I could think up.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable