### PR TITLE
CASMCMS-9282: Bump Alpine version from 3.15 to 3.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.14.0] - 2025-02-13
+### Dependencies
+- CASMCMS-9282: Bump Alpine version from 3.15 to 3.21, because 3.15 no longer receives security patches
+
 ## [1.13.0] - 2025-02-03
 ### Dependencies
 - CASMCMS-9266: Bump `golang.org/x/crypto` and `golang.org/x/net` to resolve CVEs.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020-2022, 2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020-2022, 2024-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -47,7 +47,7 @@ RUN set -ex \
 
 ### Final Stage ###
 # Start with a fresh image so build tools are not included
-FROM artifactory.algol60.net/csm-docker/stable/docker.io/library/alpine:3.15 as base
+FROM artifactory.algol60.net/csm-docker/stable/docker.io/library/alpine:3.21 as base
 
 # Install conman application from package
 RUN set -eux \


### PR DESCRIPTION
Alpine 3.15 no longer receives security patches.

I tested this on wasp and verified that it works.